### PR TITLE
feat: add API endpoint to retrieve campaigns for authenticated user f…

### DIFF
--- a/scripts/generate-openapi-client.sh
+++ b/scripts/generate-openapi-client.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Generate OpenAPI client/spec artifacts from the project's OpenAPI YAML
+# Prerequisites: openapi-generator-cli installed or placed at TOOLS/openapi-generator-cli.jar
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OPENAPI_YAML="$ROOT_DIR/src/main/resources/api/openapi.yaml"
+OUT_DIR="$ROOT_DIR/target/openapi-client"
+
+mkdir -p "$OUT_DIR"
+
+if command -v openapi-generator-cli >/dev/null 2>&1; then
+  echo "Using openapi-generator-cli from PATH"
+  openapi-generator-cli generate -i "$OPENAPI_YAML" -g openapi -o "$OUT_DIR/spec" || true
+else
+  if [ -f "$ROOT_DIR/TOOLS/openapi-generator-cli.jar" ]; then
+    echo "Using local TOOLS/openapi-generator-cli.jar"
+    java -jar "$ROOT_DIR/TOOLS/openapi-generator-cli.jar" generate -i "$OPENAPI_YAML" -g openapi -o "$OUT_DIR/spec" || true
+  else
+    echo "openapi-generator-cli not found. Install it (npm i -g @openapitools/openapi-generator-cli) or place jar in TOOLS/"
+    exit 2
+  fi
+fi
+
+cp "$OPENAPI_YAML" "$OUT_DIR/openapi.yaml"
+python3 - <<PY
+import sys, yaml, json
+with open('$OPENAPI_YAML') as f:
+    o = yaml.safe_load(f)
+with open('$OUT_DIR/openapi.json','w') as jf:
+    json.dump(o, jf, indent=2)
+print('Wrote JSON and copied YAML to', '$OUT_DIR')
+PY
+
+echo "OpenAPI client/spec generation complete. See $OUT_DIR"
+

--- a/src/main/java/com/prx/mercury/api/v1/controller/CampaignApi.java
+++ b/src/main/java/com/prx/mercury/api/v1/controller/CampaignApi.java
@@ -7,14 +7,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestHeader;
 import java.util.UUID;
 
 /**
@@ -36,12 +32,13 @@ public interface CampaignApi {
      * @param request the campaign creation request containing the channel,
      *                template, recipients and optional scheduling information.
      *                Must not be {@code null} and must pass bean validation.
-     * @return a {@link ResponseEntity} containing a {@link CreateCampaignResponse}
+     * @return a ResponseEntity containing a CreateCampaignResponse
      *         with the newly created campaign details and HTTP status {@code 201 Created}.
      */
     @Operation(
             summary = "Create a new campaign",
-            description = "Creates a new messaging campaign and publishes messages to recipients via the specified channel."
+            description = "Creates a new messaging campaign and publishes messages to recipients via the specified channel.",
+            operationId = "createCampaign"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Campaign created successfully."),
@@ -51,11 +48,7 @@ public interface CampaignApi {
             @ApiResponse(responseCode = "422", description = "Channel type not found or disabled."),
             @ApiResponse(responseCode = "500", description = "Unexpected internal error.")
     })
-    @PostMapping(
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE
-    )
-    ResponseEntity<CreateCampaignResponse> createCampaign(@RequestBody @Valid CreateCampaignRequest request);
+    ResponseEntity<CreateCampaignResponse> createCampaign(CreateCampaignRequest request);
 
     /**
      * Retrieves a campaign by its unique identifier.
@@ -64,12 +57,13 @@ public interface CampaignApi {
      * audit timestamps, status and optional metadata.</p>
      *
      * @param id the UUID of the campaign to retrieve; must be a valid UUID.
-     * @return a {@link ResponseEntity} containing a {@link CampaignDetailResponse}
+     * @return a ResponseEntity containing a CampaignDetailResponse
      *         with HTTP status {@code 200 OK}.
      */
     @Operation(
             summary = "Get campaign by ID",
-            description = "Retrieves the full details of a campaign identified by its UUID."
+            description = "Retrieves the full details of a campaign identified by its UUID.",
+            operationId = "getCampaignById"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Campaign found and returned."),
@@ -79,9 +73,22 @@ public interface CampaignApi {
             @ApiResponse(responseCode = "404", description = "Campaign with the given id does not exist."),
             @ApiResponse(responseCode = "500", description = "Unexpected internal error.")
     })
-    @GetMapping(
-            value = "/{id}",
-            produces = MediaType.APPLICATION_JSON_VALUE
+    ResponseEntity<CampaignDetailResponse> getById(UUID id);
+
+    /**
+     * Retrieves campaigns for the authenticated user filtered by application id.
+     *
+     * <p>The user id is extracted from the session token provided in the request
+     * header identified by the session token header key.</p>
+     *
+     * @param applicationId the application UUID used to filter campaigns
+     * @param sessionToken the session token header containing the user id
+     * @return a list of {@link CampaignDetailResponse} for the user and application
+     */
+    @Operation(
+            summary = "Get campaigns by application for current user",
+            description = "Retrieves campaigns filtered by application id for the authenticated user. User id is obtained from the session token header."
+            ,operationId = "getCampaignsByApplication"
     )
-    ResponseEntity<CampaignDetailResponse> getById(@PathVariable UUID id);
+    ResponseEntity<List<CampaignDetailResponse>> getByApplication(UUID applicationId, @RequestHeader("session-token") String sessionToken);
 }

--- a/src/main/java/com/prx/mercury/api/v1/controller/CampaignController.java
+++ b/src/main/java/com/prx/mercury/api/v1/controller/CampaignController.java
@@ -1,17 +1,18 @@
 package com.prx.mercury.api.v1.controller;
 
 import com.prx.mercury.api.v1.service.CampaignService;
-import com.prx.mercury.api.v1.to.CampaignDetailResponse;
-import com.prx.mercury.api.v1.to.CampaignTO;
-import com.prx.mercury.api.v1.to.CampaignProgressTO;
-import com.prx.mercury.api.v1.to.CreateCampaignRequest;
-import com.prx.mercury.api.v1.to.CreateCampaignResponse;
+import com.prx.mercury.api.v1.to.*;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
+
+import static com.prx.commons.util.JwtUtil.getUidFromToken;
+import static com.prx.security.constant.ConstantApp.SESSION_TOKEN_KEY;
 
 /**
  * REST controller that handles campaign lifecycle operations.
@@ -24,7 +25,7 @@ import java.util.UUID;
  */
 @RestController
 @RequestMapping("/api/v1/campaigns")
-public class CampaignController implements CampaignApi {
+public class CampaignController {
 
     private final CampaignService campaignService;
 
@@ -44,8 +45,8 @@ public class CampaignController implements CampaignApi {
      * delegates to {@link CampaignService#createCampaign(CampaignTO)} and maps the
      * resulting {@link CampaignProgressTO} to a {@link CreateCampaignResponse}.</p>
      */
-    @Override
-    public ResponseEntity<CreateCampaignResponse> createCampaign(CreateCampaignRequest request) {
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CreateCampaignResponse> createCampaign(@RequestBody @Valid CreateCampaignRequest request) {
         CampaignTO campaignTO = new CampaignTO(
                 request.name(),
                 request.channelTypeCode(),
@@ -78,8 +79,18 @@ public class CampaignController implements CampaignApi {
      * <p>Delegates to {@link CampaignService#getById(UUID)} and wraps the result
      * in a {@code 200 OK} response.</p>
      */
-    @Override
-    public ResponseEntity<CampaignDetailResponse> getById(UUID id) {
+    @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CampaignDetailResponse> getById(@PathVariable UUID id) {
         return ResponseEntity.ok(campaignService.getById(id));
     }
+
+    @GetMapping(value = "/application/{applicationId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<CampaignDetailResponse>> getByApplication(@PathVariable UUID applicationId, @RequestHeader(SESSION_TOKEN_KEY) String sessionToken) {
+        // extract user id from token
+        UUID userId = getUidFromToken(sessionToken);
+        // delegate to service
+        List<CampaignDetailResponse> responses = campaignService.getByUserIdAndApplicationId(userId, applicationId);
+        return ResponseEntity.ok(responses);
+    }
 }
+

--- a/src/main/java/com/prx/mercury/api/v1/controller/ChannelTypeApi.java
+++ b/src/main/java/com/prx/mercury/api/v1/controller/ChannelTypeApi.java
@@ -11,34 +11,34 @@ import java.util.UUID;
 
 @Tag(name = "channel-types", description = "Channel Type Management API")
 public interface ChannelTypeApi {
-    @Operation(description = "Get all channel types")
+    @Operation(description = "Get all channel types", operationId = "getAllChannelTypes")
     @GetMapping()
     ResponseEntity<List<ChannelTypeTO>> getAllChannelTypes();
 
-    @Operation(description = "Get enabled channel types only")
+    @Operation(description = "Get enabled channel types only", operationId = "getEnabledChannelTypes")
     @GetMapping("/enabled")
     ResponseEntity<List<ChannelTypeTO>> getEnabledChannelTypes();
 
-    @Operation(description = "Get channel type by code")
+    @Operation(description = "Get channel type by code", operationId = "getChannelTypeByCode")
     @GetMapping("/code/{code}")
     ResponseEntity<ChannelTypeTO> getChannelTypeByCode(@PathVariable String code);
 
-    @Operation(description = "Get channel type by ID")
+    @Operation(description = "Get channel type by ID", operationId = "getChannelTypeById")
     @GetMapping("/{id}")
     ResponseEntity<ChannelTypeTO> getChannelTypeById(@PathVariable UUID id);
 
-    @Operation(description = "Create new channel type")
+    @Operation(description = "Create new channel type", operationId = "createChannelType")
     @PostMapping()
     ResponseEntity<ChannelTypeTO> createChannelType(@RequestBody ChannelTypeTO channelTypeTO);
 
-    @Operation(description = "Update channel type")
+    @Operation(description = "Update channel type", operationId = "updateChannelType")
     @PutMapping("/{id}")
     ResponseEntity<ChannelTypeTO> updateChannelType(
             @PathVariable UUID id,
             @RequestBody ChannelTypeTO channelTypeTO
     );
 
-    @Operation(description = "Enable/Disable channel type")
+    @Operation(description = "Enable/Disable channel type", operationId = "toggleChannelType")
     @PatchMapping("/{id}/toggle")
     ResponseEntity<Void> toggleChannelType(
             @PathVariable UUID id,

--- a/src/main/java/com/prx/mercury/api/v1/controller/MailApi.java
+++ b/src/main/java/com/prx/mercury/api/v1/controller/MailApi.java
@@ -31,7 +31,7 @@ public interface MailApi {
      * @param requestMail the request document containing the email details
      * @return a ResponseEntity with the result of the email sending operation
      */
-    @Operation(description = "Send a email")
+    @Operation(description = "Send a email", operationId = "sendEmail")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "To send a email.")
     })

--- a/src/main/java/com/prx/mercury/api/v1/controller/VerificationCodeApi.java
+++ b/src/main/java/com/prx/mercury/api/v1/controller/VerificationCodeApi.java
@@ -28,7 +28,7 @@ public interface VerificationCodeApi {
      * @param verificationCodeRequest the request document containing the verification code details
      * @return a ResponseEntity with the result of the verification code sending operation
      */
-    @Operation(description = "Send verification code to user")
+    @Operation(description = "Send verification code to user", operationId = "sendVerificationCode")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Verification code sent successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid phone number"),
@@ -45,7 +45,7 @@ public interface VerificationCodeApi {
      * @param userId the user ID
      * @return ResponseEntity<Boolean> is_verified status or null if not found
      */
-    @Operation(description = "Get the is_verified status of the latest verification code for a user")
+    @Operation(description = "Get the is_verified status of the latest verification code for a user", operationId = "getLatestIsVerifiedStatus")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Status retrieved successfully"),
             @ApiResponse(responseCode = "404", description = "No verification code found for user"),

--- a/src/main/java/com/prx/mercury/api/v1/service/CampaignService.java
+++ b/src/main/java/com/prx/mercury/api/v1/service/CampaignService.java
@@ -5,9 +5,9 @@ import com.prx.mercury.api.v1.to.CampaignDetailResponse;
 import com.prx.mercury.api.v1.to.CampaignProgressTO;
 import com.prx.mercury.api.v1.to.CampaignTO;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
 public interface CampaignService {
 
     String PARSE_MODE_KEY = "parseMode";
@@ -29,5 +29,7 @@ public interface CampaignService {
      * @throws com.prx.mercury.api.v1.exception.CampaignNotFoundException if no campaign with the given id exists.
      */
     CampaignDetailResponse getById(UUID id);
+
+    List<CampaignDetailResponse> getByUserIdAndApplicationId(UUID userId, UUID applicationId);
 
 }

--- a/src/main/java/com/prx/mercury/api/v1/service/CampaignServiceImpl.java
+++ b/src/main/java/com/prx/mercury/api/v1/service/CampaignServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -142,7 +143,13 @@ public class CampaignServiceImpl implements CampaignService {
         return campaignMapper.toCampaignDetailResponse(entity);
     }
 
-    // ── helpers ───────────────────────────────────────────────────────────────
+    @Override
+    public List<CampaignDetailResponse> getByUserIdAndApplicationId(UUID userId, UUID applicationId) {
+        logger.debug("Fetching campaigns by user and application. userId={}, applicationId={}", userId, applicationId);
+        List<CampaignEntity> entities = campaignRepository.findByCreatedByAndApplicationId(userId, applicationId);
+        return entities.stream().map(campaignMapper::toCampaignDetailResponse).toList();
+    }
+
 
     private void validateRecipients(CampaignTO campaignTO) {
         if (campaignTO.recipients().isEmpty()) {

--- a/src/main/java/com/prx/mercury/jpa/sql/repository/CampaignRepository.java
+++ b/src/main/java/com/prx/mercury/jpa/sql/repository/CampaignRepository.java
@@ -23,4 +23,7 @@ public interface CampaignRepository extends JpaRepository<CampaignEntity, UUID> 
             String status,
             Pageable pageable
     );
+
+    java.util.List<CampaignEntity> findByCreatedByAndApplicationId(java.util.UUID createdBy, java.util.UUID applicationId);
+
 }

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -20,8 +20,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCampaignRequest'
       responses:
-        '202':
-          description: Campaign accepted and processing started.
+        '201':
+          description: Campaign created successfully.
           content:
             application/json:
               schema:
@@ -30,6 +30,71 @@ paths:
           description: Invalid request payload.
         '422':
           description: Channel type not found or disabled.
+    get:
+      tags:
+        - campaigns
+      summary: Get campaigns by application for current user
+      description: Retrieves campaigns filtered by application id for the authenticated user. User id is obtained from the session token header.
+      operationId: getCampaignsByApplication
+      parameters:
+        - name: applicationId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: session-token
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Campaigns retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CampaignDetailResponse'
+        '400':
+          description: Invalid request parameters.
+        '401':
+          description: Invalid or missing authentication token.
+        '403':
+          description: Caller lacks permission to view these campaigns.
+
+  /api/v1/campaigns/{id}:
+    get:
+      tags:
+        - campaigns
+      summary: Get campaign by ID
+      description: Retrieves the full details of a campaign identified by its UUID.
+      operationId: getCampaignById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Campaign found and returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignDetailResponse'
+        '400':
+          description: Invalid UUID format supplied for id.
+        '401':
+          description: Invalid or missing authentication token.
+        '403':
+          description: Caller lacks permission to view this campaign.
+        '404':
+          description: Campaign with the given id does not exist.
+        '500':
+          description: Unexpected internal error.
 
   /api/v1/mail:
     post:
@@ -274,6 +339,19 @@ components:
         applicationId:
           type: string
           format: uuid
+      example:
+        name: "Welcome Campaign"
+        channelTypeCode: "EMAIL"
+        templateId: "00000000-0000-0000-0000-000000000001"
+        userId: "00000000-0000-0000-0000-000000000002"
+        recipients:
+          - identifier: "user@example.com"
+            name: "Jane Doe"
+        templateParams:
+          firstName: "Jane"
+        scheduledAt: "2026-03-20T10:00:00Z"
+        status: "SCHEDULED"
+        applicationId: "00000000-0000-0000-0000-000000000003"
 
     CreateCampaignResponse:
       type: object
@@ -348,6 +426,19 @@ components:
         params:
           type: object
           additionalProperties: true
+      example:
+        templateDefinedId: "11111111-1111-1111-1111-111111111111"
+        userId: "22222222-2222-2222-2222-222222222222"
+        from: "no-reply@example.com"
+        to:
+          - email: "recipient@example.com"
+            name: "Recipient"
+        cc: []
+        subject: "Welcome to Mercury"
+        body: "Hello {{firstName}}, welcome!"
+        sendDate: "2026-03-13T12:00:00Z"
+        params:
+          firstName: "John"
 
     SendEmailResponse:
       type: object
@@ -394,6 +485,10 @@ components:
           format: uuid
         code:
           type: string
+      example:
+        applicationId: "33333333-3333-3333-3333-333333333333"
+        userId: "44444444-4444-4444-4444-444444444444"
+        code: "123456"
 
     ChannelTypeTO:
       type: object
@@ -421,4 +516,47 @@ components:
           format: date-time
         active:
           type: boolean
+      example:
+        id: "55555555-5555-5555-5555-555555555555"
+        code: "EMAIL"
+        name: "Email"
+        description: "Standard email channel"
+        icon: "mailto"
+        enabled: true
+        implementationClass: "com.prx.mercury.channel.EmailChannel"
+        createdAt: "2026-01-01T00:00:00Z"
+        updatedAt: "2026-01-02T00:00:00Z"
+        active: true
+
+    CampaignDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        channelType:
+          type: string
+        templateId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        totalRecipients:
+          type: integer
+          format: int32
+        scheduledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
 

--- a/src/test/java/com/prx/mercury/api/v1/controller/CampaignControllerTest.java
+++ b/src/test/java/com/prx/mercury/api/v1/controller/CampaignControllerTest.java
@@ -9,6 +9,7 @@ import com.prx.mercury.api.v1.to.CreateCampaignRequest;
 import com.prx.mercury.api.v1.to.CreateCampaignResponse;
 import com.prx.mercury.api.v1.to.RecipientTO;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +51,7 @@ class CampaignControllerTest {
     private UUID templateId;
     private UUID userId;
     private UUID applicationId;
+    private MockedStatic<com.prx.commons.util.JwtUtil> jwtUtilStatic;
 
     @BeforeEach
     void setUp() {
@@ -65,6 +69,12 @@ class CampaignControllerTest {
                 "DRAFT",
                 applicationId
         );
+        jwtUtilStatic = Mockito.mockStatic(com.prx.commons.util.JwtUtil.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (jwtUtilStatic != null) jwtUtilStatic.close();
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -262,6 +272,43 @@ class CampaignControllerTest {
 
             assertThrows(CampaignNotFoundException.class,
                     () -> campaignController.getById(id));
+        }
+    }
+
+    @Nested
+    @DisplayName("getByApplication tests")
+    class GetByApplication {
+
+        @Test
+        @DisplayName("parses session-token header and returns campaigns for user and application")
+        void getByApplication_success() {
+            UUID userIdLocal = UUID.randomUUID();
+            UUID appIdLocal = UUID.randomUUID();
+            UUID campaignId = UUID.randomUUID();
+
+            CampaignDetailResponse detail = new CampaignDetailResponse(campaignId, "Name", "email", UUID.randomUUID(), "DRAFT", null, null, null, null, null);
+
+            jwtUtilStatic.when(() -> com.prx.commons.util.JwtUtil.getUidFromToken("token-value")).thenReturn(userIdLocal);
+
+            when(campaignService.getByUserIdAndApplicationId(userIdLocal, appIdLocal)).thenReturn(List.of(detail));
+
+            var resp = campaignController.getByApplication(appIdLocal, "token-value");
+
+            assertThat(resp).isNotNull();
+            assertThat(resp.getStatusCode().value()).isEqualTo(200);
+            assertThat(resp.getBody()).hasSize(1);
+            verify(campaignService).getByUserIdAndApplicationId(userIdLocal, appIdLocal);
+        }
+
+        @Test
+        @DisplayName("propagates exception when token parsing fails")
+        void getByApplication_invalidToken() {
+            UUID appIdLocal = UUID.randomUUID();
+            jwtUtilStatic.when(() -> com.prx.commons.util.JwtUtil.getUidFromToken("bad-token")).thenThrow(new RuntimeException("invalid token"));
+
+            assertThrows(RuntimeException.class, () -> campaignController.getByApplication(appIdLocal, "bad-token"));
+
+            Mockito.verifyNoInteractions(campaignService);
         }
     }
 }

--- a/src/test/java/com/prx/mercury/api/v1/controller/OpenApiSpecTest.java
+++ b/src/test/java/com/prx/mercury/api/v1/controller/OpenApiSpecTest.java
@@ -1,0 +1,62 @@
+package com.prx.mercury.api.v1.controller;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.yaml.snakeyaml.Yaml;
+import io.swagger.v3.oas.annotations.Operation;
+
+class OpenApiSpecTest {
+
+    @Test
+    void openApiYamlContainsOperationIds() {
+        InputStream is = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("api/openapi.yaml");
+        assertNotNull(is, "openapi.yaml must be on classpath");
+        Yaml yaml = new Yaml();
+        Map<?,?> doc = yaml.load(is);
+        assertNotNull(doc.get("paths"), "paths must be present in openapi.yaml");
+        Map<?,?> paths = (Map<?,?>) doc.get("paths");
+        // check a handful of operationIds
+        boolean foundCreate = false;
+        boolean foundGetById = false;
+        boolean foundGetByApp = false;
+        boolean foundSendEmail = false;
+
+        for (Object pathObj : paths.values()) {
+            Map<?,?> methods = (Map<?,?>) pathObj;
+            for (Object methodObj : methods.values()) {
+                Map<?,?> method = (Map<?,?>) methodObj;
+                Object opId = method.get("operationId");
+                if ("createCampaign".equals(opId)) foundCreate = true;
+                if ("getCampaignById".equals(opId)) foundGetById = true;
+                if ("getCampaignsByApplication".equals(opId)) foundGetByApp = true;
+                if ("sendEmail".equals(opId)) foundSendEmail = true;
+            }
+        }
+        assertTrue(foundCreate, "createCampaign operationId must exist in YAML");
+        assertTrue(foundGetById, "getCampaignById operationId must exist in YAML");
+        assertTrue(foundGetByApp, "getCampaignsByApplication operationId must exist in YAML");
+        assertTrue(foundSendEmail, "sendEmail operationId must exist in YAML");
+    }
+
+    @Test
+    void interfacesContainOperationAnnotations() throws Exception {
+        // reflectively inspect CampaignApi methods
+        var cls = CampaignApi.class;
+        var m1 = cls.getMethod("createCampaign", com.prx.mercury.api.v1.to.CreateCampaignRequest.class);
+        Operation op = m1.getAnnotation(Operation.class);
+        assertNotNull(op);
+        assertEquals("createCampaign", op.operationId());
+
+        var m2 = cls.getMethod("getById", java.util.UUID.class);
+        Operation op2 = m2.getAnnotation(Operation.class);
+        assertNotNull(op2);
+        assertEquals("getCampaignById", op2.operationId());
+    }
+}
+

--- a/src/test/java/com/prx/mercury/api/v1/service/CampaignServiceImplTest.java
+++ b/src/test/java/com/prx/mercury/api/v1/service/CampaignServiceImplTest.java
@@ -388,4 +388,56 @@ class CampaignServiceImplTest {
             verify(campaignRepository).findById(unknown);
         }
     }
+
+    // ── GetByUserAndApplication ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getByUserIdAndApplicationId tests")
+    class GetByUserAndApplication {
+
+        @Test
+        @DisplayName("returns mapped list when repository finds campaigns")
+        void getByUserAndApplication_success() {
+            UUID userId = UUID.randomUUID();
+            UUID appId = UUID.randomUUID();
+            CampaignEntity e = new CampaignEntity();
+            e.setId(UUID.randomUUID());
+            e.setName("User Campaign");
+            e.setStatus("DRAFT");
+            ChannelTypeEntity channel = new ChannelTypeEntity();
+            channel.setCode("email");
+            e.setChannelType(channel);
+            TemplateDefinedEntity template = new TemplateDefinedEntity();
+            template.setId(UUID.randomUUID());
+            e.setTemplateDefined(template);
+
+            CampaignDetailResponse dto = new CampaignDetailResponse(
+                    e.getId(), e.getName(), "email", template.getId(), e.getStatus(), null, null, null, null, null);
+
+            when(campaignRepository.findByCreatedByAndApplicationId(userId, appId)).thenReturn(List.of(e));
+            when(campaignMapper.toCampaignDetailResponse(e)).thenReturn(dto);
+
+            List<CampaignDetailResponse> result = campaignServiceImpl.getByUserIdAndApplicationId(userId, appId);
+
+            assertThat(result).isNotNull();
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).id()).isEqualTo(e.getId());
+            verify(campaignRepository).findByCreatedByAndApplicationId(userId, appId);
+            verify(campaignMapper).toCampaignDetailResponse(e);
+        }
+
+        @Test
+        @DisplayName("returns empty list when repository returns none")
+        void getByUserAndApplication_empty() {
+            UUID userId = UUID.randomUUID();
+            UUID appId = UUID.randomUUID();
+            when(campaignRepository.findByCreatedByAndApplicationId(userId, appId)).thenReturn(List.of());
+
+            List<CampaignDetailResponse> result = campaignServiceImpl.getByUserIdAndApplicationId(userId, appId);
+
+            assertThat(result).isNotNull();
+            assertThat(result).isEmpty();
+            verify(campaignRepository).findByCreatedByAndApplicationId(userId, appId);
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new endpoint for retrieving campaigns by application and user, updates OpenAPI documentation and operation IDs for improved API clarity, and adds a script for generating OpenAPI client/spec artifacts. The changes also refactor the `CampaignController` implementation to directly define endpoints, and update service and repository layers to support the new query functionality.

**API Enhancements and Documentation:**

* Added a new `GET /api/v1/campaigns/application/{applicationId}` endpoint to retrieve campaigns filtered by application for the authenticated user, extracting user ID from the session token header. Updated the OpenAPI spec to document this endpoint and its parameters. [[1]](diffhunk://#diff-458863292c94279dc47ba68d025869df489f7cae2fc50ead2618a47032311a2aL81-R96) [[2]](diffhunk://#diff-4ce5abb4e50c3149efd618c83e40fd9672d814ad86abda25fbe2c6018a948e6bR33-R97)
* Updated operation IDs for all API endpoints in `CampaignApi`, `ChannelTypeApi`, `MailApi`, and `VerificationCodeApi` for better OpenAPI documentation and client generation. [[1]](diffhunk://#diff-d54fe69ac03897875634175c4c9d917d9e3442731d4054c1becd6651e0619ed3L39-R41) [[2]](diffhunk://#diff-d54fe69ac03897875634175c4c9d917d9e3442731d4054c1becd6651e0619ed3L67-R66) [[3]](diffhunk://#diff-4e1a7c70e581eb443d6bc82d3ddc9de2fdeb7e45fc90c7484dfb694ca65e2759L14-R41) [[4]](diffhunk://#diff-15f56afb1fbca9df356751fdb2caa7889a11a19170044207686cfb0c0a326a24L34-R34) [[5]](diffhunk://#diff-dedfc156b0d71264517ae055e4d290f0ec66f464857db30c01e33f7f94810c60L31-R31) [[6]](diffhunk://#diff-dedfc156b0d71264517ae055e4d290f0ec66f464857db30c01e33f7f94810c60L48-R48)

**Controller and Service Refactoring:**

* Refactored `CampaignController` to directly define endpoint methods instead of implementing `CampaignApi`, including new and existing endpoints for campaign creation, retrieval by ID, and retrieval by application/user. [[1]](diffhunk://#diff-458863292c94279dc47ba68d025869df489f7cae2fc50ead2618a47032311a2aL27-R28) [[2]](diffhunk://#diff-458863292c94279dc47ba68d025869df489f7cae2fc50ead2618a47032311a2aL47-R49) [[3]](diffhunk://#diff-458863292c94279dc47ba68d025869df489f7cae2fc50ead2618a47032311a2aL81-R96)
* Added `getByUserIdAndApplicationId` method to `CampaignService` and implemented it in `CampaignServiceImpl`, along with a new repository query in `CampaignRepository`. [[1]](diffhunk://#diff-48898221b34bb7cd86bedcc4cdcdfa4500559165d84f71ed61133586374b2b3bR33-R34) [[2]](diffhunk://#diff-90cde2975359b73b746def5c0b22a3311a43a5a1bd7421c2b45ef9b176799e83L145-R152) [[3]](diffhunk://#diff-a9e049bb48750db8dd1fd5defccd69c43caa6457fd65c53709f57329c964da0dR26-R28)

**OpenAPI Client Generation:**

* Added `scripts/generate-openapi-client.sh` to automate OpenAPI client/spec artifact generation from the project’s OpenAPI YAML file, supporting both CLI and local JAR usage.

**OpenAPI Spec Improvements:**

* Updated response codes and examples in the OpenAPI YAML for campaign creation and retrieval endpoints, ensuring consistency and clarity in API documentation. [[1]](diffhunk://#diff-4ce5abb4e50c3149efd618c83e40fd9672d814ad86abda25fbe2c6018a948e6bL23-R24) [[2]](diffhunk://#diff-4ce5abb4e50c3149efd618c83e40fd9672d814ad86abda25fbe2c6018a948e6bR342-R354)…iltered by application ID